### PR TITLE
Implement JWT Express backend with Sequelize models

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,27 @@
+require('dotenv').config();
 const express = require('express');
+const { sequelize } = require('./models');
+const userRoutes = require('./routes/users');
+const templateRoutes = require('./routes/templates');
+const documentRoutes = require('./routes/documents');
+const authMiddleware = require('./middleware/auth');
+
 const app = express();
+app.use(express.json());
+
+app.use('/users', userRoutes);
+app.use('/templates', authMiddleware, templateRoutes);
+app.use('/documents', authMiddleware, documentRoutes);
+
 const PORT = process.env.PORT || 3001;
 
-app.get('/', (req, res) => {
-  res.send('Hello from Express!');
-});
-
-app.listen(PORT, () => {
-  console.log(`Backend listening on port ${PORT}`);
-});
+(async () => {
+  try {
+    await sequelize.sync();
+    app.listen(PORT, () => {
+      console.log(`Backend listening on port ${PORT}`);
+    });
+  } catch (err) {
+    console.error('Failed to start server:', err);
+  }
+})();

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'No token provided' });
+
+  const token = authHeader.split(' ')[1];
+  jwt.verify(token, process.env.JWT_SECRET || 'secret', (err, decoded) => {
+    if (err) return res.status(401).json({ error: 'Invalid token' });
+    req.userId = decoded.userId;
+    next();
+  });
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,0 +1,39 @@
+const { Sequelize, DataTypes } = require('sequelize');
+
+const sequelize = new Sequelize(process.env.DATABASE_URL, {
+  dialect: 'postgres',
+  logging: false,
+});
+
+const User = sequelize.define('User', {
+  username: {
+    type: DataTypes.STRING,
+    unique: true,
+    allowNull: false,
+  },
+  password: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+});
+
+const Template = sequelize.define('Template', {
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  description: DataTypes.TEXT,
+  sections: DataTypes.JSONB,
+  variables: DataTypes.JSONB,
+});
+
+const Document = sequelize.define('Document', {
+  content: DataTypes.JSONB,
+});
+
+User.hasMany(Document);
+Document.belongsTo(User);
+Template.hasMany(Document);
+Document.belongsTo(Template);
+
+module.exports = { sequelize, User, Template, Document };

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,12 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2"
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "pg": "^8.11.1",
+    "sequelize": "^6.32.1"
   },
   "scripts": {
     "start": "node index.js"

--- a/backend/routes/documents.js
+++ b/backend/routes/documents.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const { Document } = require('../models');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = await Document.create({ ...req.body, UserId: req.userId });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+});
+
+router.get('/', async (req, res) => {
+  const docs = await Document.findAll({ where: { UserId: req.userId } });
+  res.json(docs);
+});
+
+router.get('/:id', async (req, res) => {
+  const doc = await Document.findOne({ where: { id: req.params.id, UserId: req.userId } });
+  if (!doc) return res.status(404).end();
+  res.json(doc);
+});
+
+router.put('/:id', async (req, res) => {
+  const doc = await Document.findOne({ where: { id: req.params.id, UserId: req.userId } });
+  if (!doc) return res.status(404).end();
+  await doc.update(req.body);
+  res.json(doc);
+});
+
+router.delete('/:id', async (req, res) => {
+  const doc = await Document.findOne({ where: { id: req.params.id, UserId: req.userId } });
+  if (!doc) return res.status(404).end();
+  await doc.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/backend/routes/templates.js
+++ b/backend/routes/templates.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const { Template } = require('../models');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const template = await Template.create(req.body);
+    res.json(template);
+  } catch (err) {
+    res.status(500).json({ error: 'Creation failed' });
+  }
+});
+
+router.get('/', async (req, res) => {
+  const templates = await Template.findAll();
+  res.json(templates);
+});
+
+router.get('/:id', async (req, res) => {
+  const template = await Template.findByPk(req.params.id);
+  if (!template) return res.status(404).end();
+  res.json(template);
+});
+
+router.put('/:id', async (req, res) => {
+  const template = await Template.findByPk(req.params.id);
+  if (!template) return res.status(404).end();
+  await template.update(req.body);
+  res.json(template);
+});
+
+router.delete('/:id', async (req, res) => {
+  const template = await Template.findByPk(req.params.id);
+  if (!template) return res.status(404).end();
+  await template.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { User } = require('../models');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+// Register
+router.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) return res.status(400).json({ error: 'Missing fields' });
+  try {
+    const hash = await bcrypt.hash(password, 10);
+    const user = await User.create({ username, password: hash });
+    res.json({ id: user.id, username: user.username });
+  } catch (err) {
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+// Login
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    const user = await User.findOne({ where: { username } });
+    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ userId: user.id }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: 'Login failed' });
+  }
+});
+
+// CRUD operations
+router.get('/', auth, async (req, res) => {
+  const users = await User.findAll({ attributes: ['id', 'username'] });
+  res.json(users);
+});
+
+router.get('/:id', auth, async (req, res) => {
+  const user = await User.findByPk(req.params.id, { attributes: ['id', 'username'] });
+  if (!user) return res.status(404).end();
+  res.json(user);
+});
+
+router.put('/:id', auth, async (req, res) => {
+  const { username, password } = req.body;
+  const user = await User.findByPk(req.params.id);
+  if (!user) return res.status(404).end();
+  if (username) user.username = username;
+  if (password) user.password = await bcrypt.hash(password, 10);
+  await user.save();
+  res.json({ id: user.id, username: user.username });
+});
+
+router.delete('/:id', auth, async (req, res) => {
+  const user = await User.findByPk(req.params.id);
+  if (!user) return res.status(404).end();
+  await user.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create PostgreSQL models for users, templates and documents
- add JWT auth middleware and CRUD routes
- connect Express app to Sequelize and sync on start
- install necessary dependencies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687116b8e768832d949e22fad00883b6