### PR TITLE
Implement JWT auth and CRUD API

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "pg": "^8.8.0"
+    "pg": "^8.8.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,25 @@
+-- PostgreSQL schema for ProposIA backend
+
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS templates (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  sections JSONB,
+  variables JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS documents (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  template_id INTEGER REFERENCES templates(id) ON DELETE SET NULL,
+  data JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,12 +1,14 @@
 const express = require('express');
-const { Pool } = require('pg');
+const pool = require('./db');
+
+const authRoutes = require('./routes/auth');
+const userRoutes = require('./routes/users');
+const templateRoutes = require('./routes/templates');
+const documentRoutes = require('./routes/documents');
 
 const app = express();
 const port = process.env.PORT || 3001;
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || 'postgres://user:password@localhost:5432/proposia'
-});
 
 app.use(express.json());
 
@@ -19,6 +21,11 @@ app.get('/', async (req, res) => {
     res.status(500).json({ error: 'Database error' });
   }
 });
+
+app.use('/auth', authRoutes);
+app.use('/users', userRoutes);
+app.use('/templates', templateRoutes);
+app.use('/documents', documentRoutes);
 
 app.listen(port, () => {
   console.log(`Server listening on port ${port}`);

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,0 +1,7 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || 'postgres://user:password@localhost:5432/proposia'
+});
+
+module.exports = pool;

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.sendStatus(401);
+
+  jwt.verify(token, process.env.JWT_SECRET || 'secret', (err, user) => {
+    if (err) return res.sendStatus(403);
+    req.user = user;
+    next();
+  });
+};

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const pool = require('../db');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const hashed = await bcrypt.hash(password, 10);
+    const { rows } = await pool.query(
+      'INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id, username',
+      [username, hashed]
+    );
+    const user = rows[0];
+    const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET || 'secret');
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const { rows } = await pool.query('SELECT * FROM users WHERE username=$1', [username]);
+    const user = rows[0];
+    if (!user) return res.status(400).json({ error: 'Invalid credentials' });
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) return res.status(400).json({ error: 'Invalid credentials' });
+    const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET || 'secret');
+    res.json({ token });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/documents.js
+++ b/backend/src/routes/documents.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const pool = require('../db');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/', auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM documents WHERE user_id=$1 ORDER BY id', [req.user.id]);
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/', auth, async (req, res) => {
+  const { template_id, data } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO documents (user_id, template_id, data) VALUES ($1, $2, $3) RETURNING *',
+      [req.user.id, template_id, data]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.get('/:id', auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM documents WHERE id=$1 AND user_id=$2', [req.params.id, req.user.id]);
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.put('/:id', auth, async (req, res) => {
+  const { data } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'UPDATE documents SET data=$1 WHERE id=$2 AND user_id=$3 RETURNING *',
+      [data, req.params.id, req.user.id]
+    );
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.delete('/:id', auth, async (req, res) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM documents WHERE id=$1 AND user_id=$2', [req.params.id, req.user.id]);
+    if (!rowCount) return res.sendStatus(404);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/templates.js
+++ b/backend/src/routes/templates.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const pool = require('../db');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM templates ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/', auth, async (req, res) => {
+  const { title, description, sections, variables } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO templates (title, description, sections, variables) VALUES ($1, $2, $3, $4) RETURNING *',
+      [title, description, sections, variables]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM templates WHERE id=$1', [req.params.id]);
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.put('/:id', auth, async (req, res) => {
+  const { title, description, sections, variables } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'UPDATE templates SET title=$1, description=$2, sections=$3, variables=$4 WHERE id=$5 RETURNING *',
+      [title, description, sections, variables, req.params.id]
+    );
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.delete('/:id', auth, async (req, res) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM templates WHERE id=$1', [req.params.id]);
+    if (!rowCount) return res.sendStatus(404);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+module.exports = router;

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const pool = require('../db');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/', auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT id, username, created_at FROM users ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.get('/:id', auth, async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT id, username, created_at FROM users WHERE id=$1', [req.params.id]);
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.put('/:id', auth, async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    let query = 'UPDATE users SET username=$1';
+    const params = [username, req.params.id];
+    if (password) {
+      const hashed = await bcrypt.hash(password, 10);
+      query = 'UPDATE users SET username=$1, password=$2 WHERE id=$3 RETURNING id, username, created_at';
+      params.splice(1, 0, hashed);
+    } else {
+      query += ' WHERE id=$2 RETURNING id, username, created_at';
+    }
+    const { rows } = await pool.query(query, params);
+    if (!rows.length) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.delete('/:id', auth, async (req, res) => {
+  try {
+    const { rowCount } = await pool.query('DELETE FROM users WHERE id=$1', [req.params.id]);
+    if (!rowCount) return res.sendStatus(404);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add PostgreSQL schema defining users, templates and documents tables
- include bcryptjs and jsonwebtoken dependencies
- refactor backend app to expose `/auth`, `/users`, `/templates` and `/documents` routes
- implement JWT authentication middleware
- create CRUD routes for users, templates and generated documents

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68711f52e5c8832db0807d7ee0f64a41